### PR TITLE
User作成のMutationにおいて、無効なパラメーターを含む場合にGraphQL APIとしてエラーを返す

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---require spec_helper
---format documentation
+--format Fuubar
+--require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -78,4 +78,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
   gem "rspec-rails"
+  gem "fuubar"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,9 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     ffi (1.15.5)
+    fuubar (2.5.1)
+      rspec-core (~> 3.0)
+      ruby-progressbar (~> 1.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
     graphiql-rails (1.8.0)
@@ -319,6 +322,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  fuubar
   graphiql-rails
   graphql
   importmap-rails

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -21,7 +21,9 @@ module Types
         address: address,
         phone: phone
       )
-      User::CreateUser.new(input).call
+      User::CreateUser.new.call(input)
+    rescue Inputs::InputInvalid => e
+      raise GraphQL::ExecutionError.new(input.errors.first.options[:message])
     end
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -11,7 +11,7 @@ module Types
       argument :phone, String, required: false
     end
     def create_user(email:, password:, first_name:, last_name:, username:, postal_code: nil, address: nil, phone: nil)
-      User.create!(
+      input = Inputs::User::CreateUserInput.new(
         email: email,
         password: password,
         first_name: first_name,
@@ -21,6 +21,7 @@ module Types
         address: address,
         phone: phone
       )
+      User::CreateUser.new(input).call
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,11 +11,12 @@ module Types
       description "Find User by ID"
       argument :id, ID, required: true
     end
-    field :users, [Types::UserType], null: false do
-      description "Fetch All Users"
-    end
     def user(id:)
       User.find(id)
+    end
+
+    field :users, [Types::UserType], null: false do
+      description "Fetch All Users"
     end
     def users(page: nil, items: nil)
       User.all

--- a/app/models/inputs/input_invalid.rb
+++ b/app/models/inputs/input_invalid.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# NOTE: ActiveRecord::RecordInvalid と同じように振る舞う
+# https://github.com/rails/rails/blob/v7.0.3.1/activerecord/lib/active_record/validations.rb#L15-L29
+class Inputs::InputInvalid < StandardError
+  attr_reader :record
+
+  def initialize(record = nil)
+    if record.present?
+      @record = record
+      errors = @record.errors.full_messages.join(", ")
+      message = I18n.t(:"#{@record.class.i18n_scope}.errors.messages.record_invalid", errors: errors, default: :"errors.messages.record_invalid")
+    else
+      message = "Record invalid"
+    end
+
+    super(message)
+  end
+end

--- a/app/models/inputs/user/create_user_input.rb
+++ b/app/models/inputs/user/create_user_input.rb
@@ -14,5 +14,5 @@ class Inputs::User::CreateUserInput
   attribute :phone, :string
 
   validates :email, :password, :first_name, :last_name, :username, presence: true
-  validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, message: "is invalid e-mail address."
+  validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, message: "Invalid e-mail address."
 end

--- a/app/models/inputs/user/create_user_input.rb
+++ b/app/models/inputs/user/create_user_input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Inputs::User::CreateUserInput
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :email, :string
+  attribute :password, :string
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :username, :string
+  attribute :postal_code, :string
+  attribute :address, :string
+  attribute :phone, :string
+
+  validates :email, :password, :first_name, :last_name, :username, presence: true
+  validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, message: "is invalid e-mail address."
+end

--- a/app/models/user/create_user.rb
+++ b/app/models/user/create_user.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class User::CreateUser
+  def initialize(input)
+    @input = input
+  end
+
+  def call
+    User.create!(
+      email:       @input.email,
+      password:    @input.password,
+      first_name:  @input.first_name,
+      last_name:   @input.last_name,
+      username:    @input.username,
+      postal_code: @input.postal_code,
+      address:     @input.address,
+      phone:       @input.phone
+    )
+  end
+end

--- a/app/models/user/create_user.rb
+++ b/app/models/user/create_user.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
 class User::CreateUser
-  def initialize(input)
-    @input = input
-  end
+  def call(input)
+    raise Inputs::InputInvalid, input if input.invalid?
 
-  def call
     User.create!(
-      email:       @input.email,
-      password:    @input.password,
-      first_name:  @input.first_name,
-      last_name:   @input.last_name,
-      username:    @input.username,
-      postal_code: @input.postal_code,
-      address:     @input.address,
-      phone:       @input.phone
+      email:       input.email,
+      password:    input.password,
+      first_name:  input.first_name,
+      last_name:   input.last_name,
+      username:    input.username,
+      postal_code: input.postal_code,
+      address:     input.address,
+      phone:       input.phone
     )
   end
 end

--- a/spec/models/inputs/user/create_user_input_spec.rb
+++ b/spec/models/inputs/user/create_user_input_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe Inputs::User::CreateUserInput do
+  describe "validations" do
+    let(:input) { described_class.new(params) }
+
+    describe "valid" do
+      let(:params) do
+        {
+          email:       "test@example.com",
+          password:    "password",
+          first_name:  "Shohei",
+          last_name:   "Ohtani",
+          username:    "john_doe",
+          postal_code: "123-4567",
+          address:     "Tokyo, Japan",
+          phone:       "03-1234-5678"
+        }
+      end
+
+      it "validation is success" do
+        expect(input.valid?).to be_truthy
+      end
+    end
+
+    describe "invalid" do
+      context "email is null" do
+        let(:params) do
+          {
+            email:       nil,
+            password:    "password",
+            first_name:  "Shohei",
+            last_name:   "Ohtani",
+            username:    "john_doe",
+            postal_code: "123-4567",
+            address:     "Tokyo, Japan",
+            phone:       "03-1234-5678"
+          }
+        end
+
+        it "validation is failed" do
+          expect(input.valid?).to be_falsey
+        end
+      end
+
+      context "email value is invalid format" do
+        let(:params) do
+          {
+            email:       "invalid_email",
+            password:    "password",
+            first_name:  "Shohei",
+            last_name:   "Ohtani",
+            username:    "john_doe",
+            postal_code: "123-4567",
+            address:     "Tokyo, Japan",
+            phone:       "03-1234-5678"
+          }
+        end
+
+        it "validation is failed" do
+          expect(input.valid?).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user/create_user_spec.rb
+++ b/spec/models/user/create_user_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe User::CreateUser do
+  describe "#call" do
+    let(:params) do
+      {
+        email:       "test@example.com",
+        password:    "password",
+        first_name:  "Shohei",
+        last_name:   "Ohtani",
+        username:    "john_doe",
+        postal_code: "123-4567",
+        address:     "Tokyo, Japan",
+        phone:       "03-1234-5678"
+      }
+    end
+
+    it "create user" do
+      input = Inputs::User::CreateUserInput.new(params)
+      expect { described_class.new(input).call }.to change(User, :count).by(1)
+    end
+  end
+end

--- a/spec/models/user/create_user_spec.rb
+++ b/spec/models/user/create_user_spec.rb
@@ -17,7 +17,14 @@ RSpec.describe User::CreateUser do
 
     it "create user" do
       input = Inputs::User::CreateUserInput.new(params)
-      expect { described_class.new(input).call }.to change(User, :count).by(1)
+      expect { described_class.new.call(input) }.to change(User, :count).by(1)
+    end
+
+    context "invalid input" do
+      it "raise InputInvalid" do
+        input = Inputs::User::CreateUserInput.new({})
+        expect { described_class.new.call(input) }.to raise_error Inputs::InputInvalid
+      end
     end
   end
 end

--- a/spec/requests/graphql/users_spec.rb
+++ b/spec/requests/graphql/users_spec.rb
@@ -5,96 +5,142 @@ RSpec.describe "Users", type: :request do
   let(:user) { create(:user) }
 
   describe "POST /graphql" do
-    it "fetch user" do
-      query_string = <<~QUERY
-        query($id: ID!) {
-          user(id: $id) {
-            id
-            email
-            firstName
-            lastName
-            username
-            postalCode
-            address
-            phone
+    describe "Query" do
+      it "fetch user" do
+        query_string = <<~QUERY
+          query($id: ID!) {
+            user(id: $id) {
+              id
+              email
+              firstName
+              lastName
+              username
+              postalCode
+              address
+              phone
+            }
           }
-        }
-      QUERY
+        QUERY
 
-      post "/graphql", params: { query: query_string, variables: { id: user.id } }
+        post "/graphql", params: { query: query_string, variables: { id: user.id } }
 
-      json = JSON.parse(response.body)
-      expect(json["data"]["user"]["id"]).to eq user.id.to_s
-      expect(json["data"]["user"]["email"]).to eq user.email
-      expect(json["data"]["user"]["firstName"]).to eq user.first_name
-      expect(json["data"]["user"]["lastName"]).to eq user.last_name
-      expect(json["data"]["user"]["username"]).to eq user.username
-      expect(json["data"]["user"]["postalCode"]).to eq user.postal_code
-      expect(json["data"]["user"]["address"]).to eq user.address
-      expect(json["data"]["user"]["phone"]).to eq user.phone
+        json = JSON.parse(response.body)
+        expect(json["data"]["user"]["id"]).to eq user.id.to_s
+        expect(json["data"]["user"]["email"]).to eq user.email
+        expect(json["data"]["user"]["firstName"]).to eq user.first_name
+        expect(json["data"]["user"]["lastName"]).to eq user.last_name
+        expect(json["data"]["user"]["username"]).to eq user.username
+        expect(json["data"]["user"]["postalCode"]).to eq user.postal_code
+        expect(json["data"]["user"]["address"]).to eq user.address
+        expect(json["data"]["user"]["phone"]).to eq user.phone
+      end
+
+      it "fetch all users" do
+        query_string = <<~QUERY
+          query {
+            users {
+              id
+            }
+          }
+        QUERY
+
+        post "/graphql", params: { query: query_string, variables: { id: user.id } }
+
+        json = JSON.parse(response.body)
+        expect(json["data"]["users"].count).to eq User.count
+      end
     end
 
-    it "fetch all users" do
-      query_string = <<~QUERY
-        query {
-          users {
-            id
-          }
+    describe "Mutations" do
+      it "create user" do
+        params = {
+          email: "john@example.com",
+          password: "password",
+          firstName: "John",
+          lastName: "Doe",
+          username: "johndoe",
+          postalCode: "123-4567",
+          address: "Tokyo, Japan",
+          phone: "03-1234-5678",
         }
-      QUERY
-
-      post "/graphql", params: { query: query_string, variables: { id: user.id } }
-
-      json = JSON.parse(response.body)
-      expect(json["data"]["users"].count).to eq User.count
-    end
-
-    it "create user" do
-      params = {
-        email: "john@example.com",
-        password: "password",
-        firstName: "John",
-        lastName: "Doe",
-        username: "johndoe",
-        postalCode: "123-4567",
-        address: "Tokyo, Japan",
-        phone: "03-1234-5678",
-      }
-      query_string = <<~QUERY
-        mutation {
-          createUser(
-            email: "#{params[:email]}"
-            password: "#{params[:password]}"
-            firstName: "#{params[:firstName]}"
-            lastName: "#{params[:lastName]}"
-            username: "#{params[:username]}"
-            postalCode: "#{params[:postalCode]}"
-            address: "#{params[:address]}"
-            phone: "#{params[:phone]}"
-          ) {
-            id
-            email
-            firstName
-            lastName
-            username
-            postalCode
-            address
-            phone
+        query_string = <<~QUERY
+          mutation {
+            createUser(
+              email: "#{params[:email]}"
+              password: "#{params[:password]}"
+              firstName: "#{params[:firstName]}"
+              lastName: "#{params[:lastName]}"
+              username: "#{params[:username]}"
+              postalCode: "#{params[:postalCode]}"
+              address: "#{params[:address]}"
+              phone: "#{params[:phone]}"
+            ) {
+              id
+              email
+              firstName
+              lastName
+              username
+              postalCode
+              address
+              phone
+            }
           }
+        QUERY
+
+        post "/graphql", params: { query: query_string }
+
+        json = JSON.parse(response.body)
+        user = json["data"]["createUser"]
+        expect(user["email"]).to eq params[:email]
+        expect(user["firstName"]).to eq params[:firstName]
+        expect(user["lastName"]).to eq params[:lastName]
+        expect(user["username"]).to eq params[:username]
+        expect(user["postalCode"]).to eq params[:postalCode]
+        expect(user["address"]).to eq params[:address]
+        expect(user["phone"]).to eq params[:phone]
+      end
+
+      it "return Error when invalid email" do
+        params = {
+          email: "invalid_email",
+          password: "password",
+          firstName: "John",
+          lastName: "Doe",
+          username: "johndoe",
+          postalCode: "123-4567",
+          address: "Tokyo, Japan",
+          phone: "03-1234-5678",
         }
-      QUERY
+        query_string = <<~QUERY
+          mutation {
+            createUser(
+              email: "#{params[:email]}"
+              password: "#{params[:password]}"
+              firstName: "#{params[:firstName]}"
+              lastName: "#{params[:lastName]}"
+              username: "#{params[:username]}"
+              postalCode: "#{params[:postalCode]}"
+              address: "#{params[:address]}"
+              phone: "#{params[:phone]}"
+            ) {
+              id
+              email
+              firstName
+              lastName
+              username
+              postalCode
+              address
+              phone
+            }
+          }
+        QUERY
 
-      post "/graphql", params: { query: query_string }
+        post "/graphql", params: { query: query_string }
 
-      json = JSON.parse(response.body)
-      user = json["data"]["createUser"]
-      expect(user["email"]).to eq params[:email]
-      expect(user["firstName"]).to eq params[:firstName]
-      expect(user["lastName"]).to eq params[:lastName]
-      expect(user["username"]).to eq params[:username]
-      expect(user["postalCode"]).to eq params[:postalCode]
-      expect(user["address"]).to eq params[:address]
-      expect(user["phone"]).to eq params[:phone]
+        json = JSON.parse(response.body)
+        expect(json["data"]).to be_nil
+        expect(json["errors"][0]["message"]).to eq "Invalid e-mail address."
+      end
     end
   end
 end


### PR DESCRIPTION
## issue

Closes #6 

## スクショ
無効なemailを含むパラメーターでリクエストをした時にエラーが返却される

<img width="930" alt="スクリーンショット 2023-01-10 16 22 30" src="https://user-images.githubusercontent.com/7115171/211487927-2bbbf829-a1ae-4add-812b-49556c72f759.png">

## リファクタリング

ユーザー作成のMutationで、`mutation_type.rb` 内のfield関数でORMの処理を実装していたが、`graphql-ruby` ではPORO(Plain Old Ruby Object)でresolverの処理を分割することを推奨していたので、[こちらの記事](https://graphql-ruby.org/fields/resolvers.html#first-ask-yourself-) に基づいてリファクタリングした。

該当コミット
- https://github.com/samuraikun/graphql-ruby-hands-on/pull/8/commits/e30631ad4be7dcd9d7029e6934b68db54477079e
- https://github.com/samuraikun/graphql-ruby-hands-on/pull/8/commits/f8949082ee00f95fe2f05b83a5c8a9a5107f75c0
