### PR TITLE
Dataloaderを利用してN+1を回避するクエリを実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "factory_bot_rails"
   gem "faker"
+  gem "bullet"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "factory_bot_rails"
+  gem "faker"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "graphql"
+gem "batch-loader"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     backport (1.2.0)
+    batch-loader (2.0.1)
     bcrypt (3.1.18)
     benchmark (0.2.1)
     bindex (0.8.1)
@@ -323,6 +324,7 @@ PLATFORMS
   aarch64-linux
 
 DEPENDENCIES
+  batch-loader
   bcrypt (~> 3.1.7)
   bootsnap
   bullet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.1.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     fuubar (2.5.1)
       rspec-core (~> 3.0)
@@ -322,6 +324,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  faker
   fuubar
   graphiql-rails
   graphql

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.37.1)
       addressable
       matrix
@@ -295,6 +298,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -321,6 +325,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
+  bullet
   capybara
   debug
   factory_bot_rails

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -5,5 +5,6 @@ module Types
     field :body, String, null: false
     field :user, Types::UserType, null: false
     field :comments, [Types::CommentType], null: true
+    field :tags, [Types::TagType], null: true
   end
 end

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -4,7 +4,21 @@ module Types
     field :title, String, null: false
     field :body, String, null: false
     field :user, Types::UserType, null: false
-    field :comments, [Types::CommentType], null: true
-    field :tags, [Types::TagType], null: true
+    field :comments, [Types::CommentType], null: true, preload: { comments: :user }
+    field :tags, [Types::TagType], null: true, preload: { taggings: :tag }
+
+    def user
+      BatchLoader::GraphQL.for(object.user_id).batch do |user_ids, loader|
+        User.where(id: user_ids).each { |user| loader.call(user.id, user) }
+      end
+    end
+
+    def comments
+      BatchLoader::GraphQL.for(object.id).batch(default_value: []) do |article_ids, loader|
+        Comment.where(article_id: article_ids).each do |comment|
+          loader.call(comment.article_id) { |memo| memo << comment }
+        end
+      end
+    end
   end
 end

--- a/app/graphql/types/article_type.rb
+++ b/app/graphql/types/article_type.rb
@@ -1,0 +1,9 @@
+module Types
+  class ArticleType < Types::BaseObject
+    field :id, ID, null: false
+    field :title, String, null: false
+    field :body, String, null: false
+    field :user, Types::UserType, null: false
+    field :comments, [Types::CommentType], null: true
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -3,5 +3,6 @@ module Types
     edge_type_class(Types::BaseEdge)
     connection_type_class(Types::BaseConnection)
     field_class Types::BaseField
+    field_class Types::PreloadableField
   end
 end

--- a/app/graphql/types/comment_type.rb
+++ b/app/graphql/types/comment_type.rb
@@ -1,0 +1,8 @@
+module Types
+  class CommentType < Types::BaseObject
+    field :id, ID, null: false
+    field :body, String, null: false
+    field :user, Types::UserType, null: true
+    field :article, Types::ArticleType, null: true
+  end
+end

--- a/app/graphql/types/preloadable_field.rb
+++ b/app/graphql/types/preloadable_field.rb
@@ -1,0 +1,15 @@
+class Types::PreloadableField < Types::BaseField
+  def initialize(*args, preload: nil, **kwargs, &block)
+    @preloads = preload
+    super(*args, **kwargs, &block)
+  end
+
+  def resolve(type, args, ctx)
+    return super unless @preloads
+
+    BatchLoader::GraphQL.for(type).batch(key: self) do |records, loader|
+      ActiveRecord::Associations::Preloader.new(records: records.map(&:object), associations: @preloads)
+      records.each { |r| loader.call(r, super(r, args, ctx)) }
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,5 +21,47 @@ module Types
     def users(page: nil, items: nil)
       User.all
     end
+
+    field :article, Types::ArticleType, null: true do
+      argument :id, ID, required: true
+    end
+    def article(id:)
+      Article.find(id)
+    end
+
+    field :articles, [Types::ArticleType], null: true do
+      argument :user_id, ID, required: false
+    end
+    def articles(user_id: nil)
+      if user_id
+        Article.where(user_id: user_id)
+      else
+        Article.all
+      end
+    end
+
+    field :comments, [Types::CommentType], null: false do
+      argument :id, ID, required: false
+      argument :user_id, ID, required: false
+      argument :article_id, ID, required: false
+    end
+    def comments(id: nil, user_id: nil, article_id: nil)
+      scope = Comment.all
+      scope = scope.where(id: id) if id
+      scope = scope.where(user_id: user_id) if user_id
+      scope = scope.where(article_id: article_id) if article_id
+      scope
+    end
+
+    field :tags, [Types::TagType], null: false do
+      argument :name, String, required: false
+    end
+    def tags(name: nil)
+      if name
+        Tag.where("name like ?", "#{name}%")
+      else
+        Tag.all
+      end
+    end
   end
 end

--- a/app/graphql/types/tag_type.rb
+++ b/app/graphql/types/tag_type.rb
@@ -1,0 +1,5 @@
+class Types::TagType < Types::BaseObject
+  field :id, ID, null: false
+  field :name, String, null: false
+  field :articles, [Types::ArticleType], null: true
+end

--- a/app/graphql/workspace_schema.rb
+++ b/app/graphql/workspace_schema.rb
@@ -2,8 +2,8 @@ class WorkspaceSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
 
-  # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
-  use GraphQL::Dataloader
+  # For batch-loading (see https://github.com/exAspArk/batch-loader)
+  use BatchLoader::GraphQL
 
   # GraphQL-Ruby calls this when something goes wrong while running a query:
   def self.type_error(err, context)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,6 @@
+class Article < ApplicationRecord
+  belongs_to :user
+  has_many :comments
+  has_many :taggings
+  has_many :tags, through: :taggings
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,5 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+  validates :body, presence: true, length: { minimum: 3 }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,11 @@
+class Tag < ApplicationRecord
+  has_many :taggings
+  has_many :articles, through: :taggings
+  validates :name, presence: true, uniqueness: true
+  before_save :downcase_name
+
+  private
+  def downcase_name
+    self.name.downcase!
+  end
+end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,4 @@
+class Tagging < ApplicationRecord
+  belongs_to :article
+  belongs_to :tag
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,7 @@
 class User < ApplicationRecord
+  has_many :comments
+  has_many :articles, foreign_key: "user_id"
+  validates :username, presence: true
+  validates :email, presence: true, uniqueness: true
   has_secure_password
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/db/migrate/20230111052914_create_articles.rb
+++ b/db/migrate/20230111052914_create_articles.rb
@@ -1,0 +1,11 @@
+class CreateArticles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :articles do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230111052940_create_comments.rb
+++ b/db/migrate/20230111052940_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230111052953_create_tags.rb
+++ b/db/migrate/20230111052953_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230111053003_create_taggings.rb
+++ b/db/migrate/20230111053003_create_taggings.rb
@@ -1,0 +1,10 @@
+class CreateTaggings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :taggings do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_08_035416) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_11_053003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_taggings_on_article_id"
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -29,4 +63,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_08_035416) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
+  add_foreign_key "taggings", "articles"
+  add_foreign_key "taggings", "tags"
 end

--- a/spec/requests/graphql/articles_spec.rb
+++ b/spec/requests/graphql/articles_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe "Articles", type: :request do
       post "/graphql", params: { query: query_string, variables: { userId: @user.id } }
 
       json = JSON.parse(response.body)
-      binding.irb
       expect(json["data"]["articles"][0]["title"]).to eq "test"
     end
   end

--- a/spec/requests/graphql/articles_spec.rb
+++ b/spec/requests/graphql/articles_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe "Articles", type: :request do
   before "create test data" do
     @user = create(:user)
-    create(:article, user: @user, title: "test")
+    @article = create(:article, user: @user, title: "test")
   end
 
   describe "Query Article" do
-    it "fetch article include user, comments, tags" do
+    it "fetch article include user, comments(belonging resource & has_many resources)" do
       query_string = <<~QUERY
         query($userId: ID!) {
           articles(userId: $userId) {
@@ -17,12 +17,6 @@ RSpec.describe "Articles", type: :request do
             }
             comments {
               body
-              user {
-                username
-              }
-            }
-            tags {
-              name
             }
           }
         }
@@ -31,7 +25,9 @@ RSpec.describe "Articles", type: :request do
       post "/graphql", params: { query: query_string, variables: { userId: @user.id } }
 
       json = JSON.parse(response.body)
-      expect(json["data"]["articles"][0]["title"]).to eq "test"
+      articles = json["data"]["articles"]
+      expect(articles[0]["title"]).to eq "test"
+      expect(articles[0]["comments"][0]["body"]).to eq @article.comments.first.body
     end
   end
 end

--- a/spec/requests/graphql/articles_spec.rb
+++ b/spec/requests/graphql/articles_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Articles", type: :request do
+  before "create test data" do
+    @user = create(:user)
+    create(:article, user: @user, title: "test")
+  end
+
+  describe "Query Article" do
+    it "fetch article include user, comments, tags" do
+      query_string = <<~QUERY
+        query($userId: ID!) {
+          articles(userId: $userId) {
+            title
+            user {
+              username
+            }
+            comments {
+              body
+              user {
+                username
+              }
+            }
+            tags {
+              name
+            }
+          }
+        }
+      QUERY
+
+      post "/graphql", params: { query: query_string, variables: { userId: @user.id } }
+
+      json = JSON.parse(response.body)
+      binding.irb
+      expect(json["data"]["articles"][0]["title"]).to eq "test"
+    end
+  end
+end

--- a/spec/requests/graphql/users_spec.rb
+++ b/spec/requests/graphql/users_spec.rb
@@ -1,4 +1,3 @@
-# spec/requests/users_spec.rb
 require "rails_helper"
 
 RSpec.describe "Users", type: :request do

--- a/test/factories/articles.rb
+++ b/test/factories/articles.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :article do
+    association :user
+    title { Faker::Lorem.sentence }
+    body { Faker::Lorem.paragraph }
+
+    after(:create) do |article|
+      user = create(:user, email: "#{Faker::Lorem.word}@example.com", username: "#{Faker::Name.last_name.downcase}_#{SecureRandom.uuid}")
+      create_list(:comment, 3, article: article, user: user)
+      tags = create_list(:tag, 2)
+      tags.each { |tag| create(:tagging, tag: tag, article: article) }
+    end
+  end
+end

--- a/test/factories/comments.rb
+++ b/test/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    association :user
+    association :article
+    body { Faker::Lorem.paragraph }
+  end
+end

--- a/test/factories/taggings.rb
+++ b/test/factories/taggings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tagging do
+    association :tag
+    association :article
+  end
+end

--- a/test/factories/tags.rb
+++ b/test/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { Faker::Lorem.word }
+  end
+end

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tagging_test.rb
+++ b/test/models/tagging_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TaggingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# issue

Closes #9 

## Dataloader用にUserに対して、1:Nのリレーションを持つモデルを用意
サンプル用に一般的なブログサービスでよくあるテーブル設計にしている。

※ 各テーブルのカラムは一部省略

```mermaid
erDiagram

users ||--o{ articles: ""
users ||--o{ comments: ""
articles ||--o{ comments: ""
articles ||--o{ taggings: ""
tags ||--o{ taggings: ""

users {
  string email
  string username
}

articles {
  string title
  text body
}

comments {
  text body
  integer user_id
  integer article_id
}

taggings {
  integer article_id
  integer tag_id
}

tags {
  string name
}
```